### PR TITLE
Remove `*.cabal` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,5 +205,3 @@ tags
 [._]*.un~
 
 # End of https://www.gitignore.io/api/macOS,vim,Intellij+iml,emacs,haskell,cabal,stack
-
-*.cabal


### PR DESCRIPTION
Please consider removing `*.cabal` from `.gitignore` to allow the project to be built using cabal as well.

For context I'm currently migrating a project that uses `hal` from stack to cabal. Currently cabal can't build the project because of the missing cabal file in `hal` and once the build fails, I have to manually go into hal's work dir and run `hpack` to generate `hal.cabal` from `package.yaml` so that the build can continue.